### PR TITLE
fix: Add CodeQL suppression for defender-for-devops false positive

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -38,3 +38,9 @@ query-filters:
         - '**/xss-scanner.ts'
         - '**/sql-injection-scanner.ts'
         - '**/secret-scanner.ts'
+  # Suppress false positive for non-existent workflow file
+  - exclude:
+      id:
+        - actions/missing-workflow-permissions
+      paths:
+        - '.github/workflows/defender-for-devops.yml'


### PR DESCRIPTION
**Issue:**
CodeQL repeatedly reports missing permissions in non-existent file: `.github/workflows/defender-for-devops.yml`

**Solution:**
Added proper query filter in codeql-config.yml to suppress this false positive

**Verification:**
- File does not exist: `git ls-files | grep defender` returns nothing
- All actual workflows have proper permissions configured
- ci.yml, codeql.yml, security.yml all have explicit permissions blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [ ] Tests added/updated
- [ ] All tests passing
- [ ] Manually tested with MCP interface

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings introduced
- [ ] Added tests that prove fix/feature works
