### PR TITLE
fix: Make Codecov upload non-blocking and optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
       - name: Upload coverage reports
         uses: codecov/codecov-action@v4
         if: matrix.node-version == '20.x'
+        continue-on-error: true
         with:
           files: ./coverage/coverage-final.json
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint and Type Check


### PR DESCRIPTION
**Issue:**
- Codecov upload failing on main branch: "Token required - not valid tokenless upload"
- Main branch is protected, requires CODECOV_TOKEN secret
- CI should not fail if external coverage service is unavailable

**Changes:**
- Added `continue-on-error: true` to Codecov upload step
- Changed `fail_ci_if_error: false` (don't fail CI on upload errors)
- Added `token: ${{ secrets.CODECOV_TOKEN }}` for when token is available
- Coverage enforcement still strict via local check-coverage.js script

**Rationale:**
- Coverage thresholds already enforced locally (60% statements, 50% branches)
- Codecov is nice-to-have for historical tracking, not required for CI pass
- If CODECOV_TOKEN secret is set, upload succeeds
- If not set, upload skips gracefully without failing CI

**Impact:**
✅ CI will pass even without Codecov token
✅ Coverage still enforced at 60%/50% thresholds
✅ Can add CODECOV_TOKEN secret later to enable uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [ ] Tests added/updated
- [ ] All tests passing
- [ ] Manually tested with MCP interface

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings introduced
- [ ] Added tests that prove fix/feature works
