### PR TITLE
fix: Add explicit permissions to Defender for DevOps workflow

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -31,6 +31,11 @@ jobs:
     # currently only windows latest is supported
     runs-on: windows-latest
 
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
**Issue:**
- CodeQL flagged missing permissions in defender-for-devops.yml
- Without explicit permissions, workflow inherits repository-wide permissions
- Violates principle of least privilege

**Changes:**
Added explicit permissions block to MSDO job:
- `contents: read` - Required to checkout code
- `security-events: write` - Required to upload SARIF results to Security tab
- `actions: read` - Required to read workflow run metadata

**Security Impact:**
✅ Follows principle of least privilege
✅ Limits token scope to only what's needed
✅ Prevents accidental write access to repository
✅ Complies with GitHub Actions security best practices

**References:**
- CodeQL rule: actions/missing-workflow-permissions
- GitHub docs: https://docs.github.com/en/actions/security-guides/automatic-token-authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [ ] Tests added/updated
- [ ] All tests passing
- [ ] Manually tested with MCP interface

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings introduced
- [ ] Added tests that prove fix/feature works
