### PR TITLE
fix: Remove unused CodeIssue import from auto-fixer

### DIFF
--- a/packages/smart-reviewer/src/auto-fixer.ts
+++ b/packages/smart-reviewer/src/auto-fixer.ts
@@ -1,6 +1,5 @@
 import { parse } from '@babel/parser';
 import type { File } from '@babel/types';
-import { CodeIssue } from './types.js';
 import { INDEX } from './constants/auto-fixer.js';
 import {
   type FixContext,


### PR DESCRIPTION
**Issue:**
- CodeQL flagged unused import: CodeIssue from './types.js'
- Import was never used in the file
- Makes code harder to read and maintain

**Changes:**
- Removed unused `import { CodeIssue } from './types.js'`

**Validation:**
✅ All 27 smart-reviewer tests passing
✅ Build successful
✅ No impact on functionality

**Related:**
- CodeQL rule: js/unused-local-variable
- Part of code quality cleanup for PR #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of changes

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [ ] Tests added/updated
- [ ] All tests passing
- [ ] Manually tested with MCP interface

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings introduced
- [ ] Added tests that prove fix/feature works
